### PR TITLE
Added CI configuration for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+  - "node"
+  - "lts/*"
+before_script:
+  - yarn
+script: yarn build
+cache:
+  yarn: true
+  directories:
+    - node_modules


### PR DESCRIPTION
This CI config will run `yarn` and `yarn build` with the latest NodeJs version and the latest NodeJs LTS version. The `yarn build` task already includes linting, so there is no need to run it seperatly.